### PR TITLE
Remove Warning: componentWillReceiveProps by change it componentDidUpdate

### DIFF
--- a/lib/Toast.js
+++ b/lib/Toast.js
@@ -82,7 +82,7 @@ class Toast extends Component {
       />)
   };
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(nextProps) {
     this.toast.update(
       <ToastContainer
         {...nextProps}

--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -75,7 +75,7 @@ class ToastContainer extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(nextProps) {
     if (nextProps.visible !== this.props.visible) {
       if (nextProps.visible) {
         clearTimeout(this.showTimeout)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tiny-toast",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "😊A react native toast like component , it works on IOS and Android.",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
in **react native version 0.61** componentWillReceiveProps is getting warning because it's going to be removed. [`check it here for reference`](https://reactjs.org/docs/react-component.html)